### PR TITLE
Add support for video resolution preference

### DIFF
--- a/Client/src/camera/CameraFactory.cpp
+++ b/Client/src/camera/CameraFactory.cpp
@@ -4,7 +4,7 @@
 #include "OCVCamera.h"
 #include "NullCamera.h"
 
-Camera* CameraFactory::buildCamera()
+Camera* CameraFactory::buildCamera(int width, int height)
 {
 	Camera *camera = NULL;
 	bool error = false;
@@ -17,11 +17,11 @@ Camera* CameraFactory::buildCamera()
 	{
 		has_ps3 = false;
 	}
-	
+
 	if (!has_ps3)
 	{
 		try {
-			camera = new OCVCamera;
+			camera = new OCVCamera(width, height);
 		}
 		catch (std::exception)
 		{

--- a/Client/src/camera/CameraFactory.h
+++ b/Client/src/camera/CameraFactory.h
@@ -5,6 +5,6 @@
 class CameraFactory
 {
 public:
-	Camera* buildCamera();
+	Camera* buildCamera(int width, int height);
 };
 

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -14,6 +14,8 @@ ConfigData ConfigData::getGenericConfig()
 	conf.prior_distance = .6;
 	conf.show_video_feed = true;
 	conf.selected_model = 0;
+	conf.video_width = 640;
+	conf.video_height = 480;
 	return conf;
 }
 
@@ -39,6 +41,8 @@ void ConfigMgr::updateConfig(const ConfigData& data)
 	conf.setValue("prior_distance", data.prior_distance);
 	conf.setValue("video_feed", data.show_video_feed);
 	conf.setValue("model", data.selected_model);
+	conf.setValue("video_width", data.video_width);
+	conf.setValue("video_height", data.video_height);
 }
 
 ConfigData ConfigMgr::getConfig()
@@ -51,6 +55,8 @@ ConfigData ConfigMgr::getConfig()
 	c.prior_distance = conf.value("prior_distance", 0.0).toDouble();
 	c.show_video_feed = conf.value("video_feed", true).toBool();
 	c.selected_model = conf.value("model", 0).toInt();
+	c.video_width = conf.value("video_width", 640).toInt();
+	c.video_height = conf.value("video_height", 480).toInt();
 	return c;
 }
 

--- a/Client/src/model/Config.h
+++ b/Client/src/model/Config.h
@@ -12,6 +12,8 @@ struct ConfigData
 {
 	std::string ip;
 	int port;
+	int video_height;
+	int video_width;
 	double prior_pitch, prior_yaw, prior_distance;
 	bool show_video_feed;
 

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -14,7 +14,7 @@ Presenter::Presenter(IView& view, TrackerFactory* t_factory, ConfigMgr* conf_mgr
 	this->view = &view;
 	this->view->connect_presenter(this);
 	this->paint = state.show_video_feed;
-	
+
 
 	this->tracker_factory = t_factory;
 
@@ -27,7 +27,7 @@ Presenter::Presenter(IView& view, TrackerFactory* t_factory, ConfigMgr* conf_mgr
 
 
 	CameraFactory camfactory;
-	camera = camfactory.buildCamera();
+	camera = camfactory.buildCamera(state.video_width, state.video_height);
 
 	if (!camera->is_valid)
 	{
@@ -50,7 +50,7 @@ Presenter::Presenter(IView& view, TrackerFactory* t_factory, ConfigMgr* conf_mgr
 		this->tracker_factory->get_model_names(state.model_names);
 
 	}
-	
+
 	// Check if there was a problem initing tracker
 	if (this->t == nullptr)
 	{
@@ -62,7 +62,7 @@ Presenter::Presenter(IView& view, TrackerFactory* t_factory, ConfigMgr* conf_mgr
 
 Presenter::~Presenter()
 {
-	delete this->udp_sender; 
+	delete this->udp_sender;
 	delete this->camera;
 	delete this->t;
 	delete this->filter;
@@ -75,7 +75,7 @@ void Presenter::init_sender(std::string &ip, int port)
 	if (this->udp_sender != NULL)
 		if (ip != this->udp_sender->ip && port != this->udp_sender->port)
 			return;
-	
+
 	if (this->udp_sender != NULL)
 		delete(this->udp_sender);
 
@@ -163,7 +163,7 @@ void Presenter::run_loop()
 				cv::Point p2(d.face_coords[2], d.face_coords[3]);
 				cv::rectangle(mat, p1, p2, color_blue, 1);
 			}
-			
+
 
 			send_data(buffer_data, d);
 		}
@@ -220,7 +220,7 @@ void Presenter::save_prefs(const ConfigData& data)
 	int port = data.port;
 	init_sender(ip_str, port);
 
-	// Rebuild tracker if needed. This will take care of updating the 
+	// Rebuild tracker if needed. This will take care of updating the
 	// state also
 	init_tracker(data.selected_model);
 


### PR DESCRIPTION
This seems to be one case for a failure from Issue #11 , the CameraFactory always tries to use 640x480 camera resolution, which isn't necessarily the resolution of the attached camera. I've added the ability to specify values in the prefs.ini for specific camera resolutions (e.g. in my case 1280x720 was required).

(Whitespace edits are because I have a VS plugin to remove them).