### PR TITLE
Bugfixes

### DIFF
--- a/AITracker/src/PositionSolver.cpp
+++ b/AITracker/src/PositionSolver.cpp
@@ -109,7 +109,7 @@ void PositionSolver::set_prior_yaw(float new_yaw)
 
 void PositionSolver::set_prior_distance(float new_distance)
 {
-    this->prior_distance = new_distance;
+    this->prior_distance = new_distance * -2.;
     this->tv[2] = this->prior_distance;
 }
 

--- a/AITracker/src/imageprocessor.cpp
+++ b/AITracker/src/imageprocessor.cpp
@@ -10,9 +10,17 @@ ImageProcessor::ImageProcessor() :
 	std_scaling *= 255.0f;
 }
 
-void ImageProcessor::normalize(cv::Mat& image) 
+void ImageProcessor::normalize(cv::Mat& image)
 {
-	cv::divide(image, std_scaling, image);
+    cv::divide(image, std_scaling, image);
+
+    /*float* ptr = image.ptr<float>();
+    for (int channel = 0; channel < 3; channel++){
+        for (int i = 0; i < 224 * 224; i++) {
+            ptr[224*224*channel + i] /= std_scaling[channel];
+        }
+    }*/
+
 	cv::subtract(image, mean_scaling, image);
 }
 

--- a/Client/src/Main.cpp
+++ b/Client/src/Main.cpp
@@ -14,6 +14,7 @@
 int main(int argc, char *argv[])
 {
    
+    SetEnvironmentVariable(LPWSTR("OMP_NUM_THREADS"), LPWSTR("1"));
     omp_set_num_threads(1);  // Disable ONNX paralelization so we dont steal all cpu cores.
     omp_set_dynamic(0);
 

--- a/Client/src/Main.cpp
+++ b/Client/src/Main.cpp
@@ -28,37 +28,6 @@ int main(int argc, char *argv[])
 
     ConfigMgr conf_mgr("./prefs.ini");
     TrackerFactory t_factory("./models/");
-
-    /*ConfigData conf_prefs = conf_mgr.getConfig();
-
-
-    int img_width = 640;
-    int img_heigth = 480;
-    float solver_prior_pitch = conf_prefs.prior_pitch;
-    float solver_prior_yaw = conf_prefs.prior_yaw;
-    float solver_prior_distance = conf_prefs.prior_distance;
-
-
-
-    char* ENV_MODEL_D__PATH = std::getenv("AITRACK_MODEL_DETECT");
-    char* ENV_MODEL_LD_PATH = std::getenv("AITRACK_MODEL_LANDMARK");
-    std::wstring MODEL_DETECT_PATH, MODEL_LANDMARK_PATH;
-    if (ENV_MODEL_D__PATH == NULL)
-    {
-        MODEL_DETECT_PATH = QString(std::string("./models/mnv3_detection_opt.onnx").data()).toStdWString();
-        MODEL_LANDMARK_PATH = QString(std::string("./models/mnv3_opt_b.onnx").data()).toStdWString();
-    }
-    else
-    {
-        MODEL_DETECT_PATH = QString(ENV_MODEL_D__PATH).toStdWString();
-        MODEL_LANDMARK_PATH = QString(ENV_MODEL_LD_PATH).toStdWString();
-    }
-    */
-    //PositionSolver solver = PositionSolver(img_width, img_heigth, solver_prior_pitch, solver_prior_yaw, solver_prior_distance);
-    //Tracker *t = new Tracker(&solver, MODEL_DETECT_PATH, MODEL_LANDMARK_PATH);
-
-    //Tracker* t = TrackerFactory::buildTracker("./models/", 122, 122, 0.6);
-
     
     Presenter p((IView&)w, &t_factory, (ConfigMgr*)&conf_mgr);
 

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -3,14 +3,13 @@
 
 OCVCamera::OCVCamera(int width, int height, int fps) :
 	Camera(width, height, fps),
+	size(width, height),
 	cap()
 {
 	if (!is_camera_available())
 	{
 		throw std::runtime_error("No compatible camera found.");
 	}
-	cap.set(cv::CAP_PROP_FRAME_WIDTH, width);
-	cap.set(cv::CAP_PROP_FRAME_HEIGHT, height);
 	is_valid = true;
 }
 
@@ -49,6 +48,7 @@ void OCVCamera::get_frame(uint8_t* buffer)
 {
 	cv::Mat frame;
 	cap.read(frame);
+	cv::resize(frame, frame, size);
 	cv::flip(frame, frame, 1);
 	for (int i = 0; i < frame.cols * frame.rows * 3; i++)
 		buffer[i] = frame.data[i];

--- a/Client/src/camera/OCVCamera.h
+++ b/Client/src/camera/OCVCamera.h
@@ -6,6 +6,7 @@ class OCVCamera : public Camera
 {
 private:
 	cv::VideoCapture cap;
+	cv::Size size;
 
 	bool is_camera_available();
 

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -16,6 +16,8 @@ ConfigData ConfigData::getGenericConfig()
 	conf.selected_model = 0;
 	conf.video_width = 640;
 	conf.video_height = 480;
+	conf.use_landmark_stab = true;
+	conf.x, conf.y, conf.z, conf.pitch, conf.yaw, conf.roll = 0;
 	return conf;
 }
 
@@ -43,6 +45,7 @@ void ConfigMgr::updateConfig(const ConfigData& data)
 	conf.setValue("model", data.selected_model);
 	conf.setValue("video_width", data.video_width);
 	conf.setValue("video_height", data.video_height);
+	conf.setValue("stabilize_landmarks", data.use_landmark_stab);
 }
 
 ConfigData ConfigMgr::getConfig()
@@ -54,6 +57,7 @@ ConfigData ConfigMgr::getConfig()
 	c.prior_yaw = conf.value("prior_yaw", 0.0).toDouble();
 	c.prior_distance = conf.value("prior_distance", 0.0).toDouble();
 	c.show_video_feed = conf.value("video_feed", true).toBool();
+	c.use_landmark_stab = conf.value("stabilize_landmarks", true).toBool();
 	c.selected_model = conf.value("model", 0).toInt();
 	c.video_width = conf.value("video_width", 640).toInt();
 	c.video_height = conf.value("video_height", 480).toInt();

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -18,9 +18,6 @@ ConfigData ConfigData::getGenericConfig()
 }
 
 
-
-
-
 ConfigMgr::ConfigMgr(std::string ini_path):
 	conf(ini_path.data(), QSettings::IniFormat)
 {

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -16,6 +16,7 @@ ConfigData ConfigData::getGenericConfig()
 	conf.selected_model = 0;
 	conf.video_width = 640;
 	conf.video_height = 480;
+	conf.video_fps = 30;
 	conf.use_landmark_stab = true;
 	conf.x, conf.y, conf.z, conf.pitch, conf.yaw, conf.roll = 0;
 	return conf;
@@ -46,6 +47,7 @@ void ConfigMgr::updateConfig(const ConfigData& data)
 	conf.setValue("video_width", data.video_width);
 	conf.setValue("video_height", data.video_height);
 	conf.setValue("stabilize_landmarks", data.use_landmark_stab);
+	conf.setValue("fps", data.video_fps);
 }
 
 ConfigData ConfigMgr::getConfig()
@@ -61,6 +63,7 @@ ConfigData ConfigMgr::getConfig()
 	c.selected_model = conf.value("model", 0).toInt();
 	c.video_width = conf.value("video_width", 640).toInt();
 	c.video_height = conf.value("video_height", 480).toInt();
+	c.video_fps = conf.value("fps", 30).toInt();
 	return c;
 }
 

--- a/Client/src/model/Config.h
+++ b/Client/src/model/Config.h
@@ -16,6 +16,9 @@ struct ConfigData
 	int video_width;
 	double prior_pitch, prior_yaw, prior_distance;
 	bool show_video_feed;
+	bool use_landmark_stab;
+
+	float x, y, z, yaw, pitch, roll;
 
 	std::vector<std::string> model_names;
 	int selected_model;

--- a/Client/src/model/Config.h
+++ b/Client/src/model/Config.h
@@ -14,6 +14,7 @@ struct ConfigData
 	int port;
 	int video_height;
 	int video_width;
+	int video_fps;
 	double prior_pitch, prior_yaw, prior_distance;
 	bool show_video_feed;
 	bool use_landmark_stab;

--- a/Client/src/model/Config.h
+++ b/Client/src/model/Config.h
@@ -3,6 +3,11 @@
 #include <string>
 #include <QSettings>
 
+
+/**
+* Struct which holds both the program state and the serializable part of this
+* state (aka. preferences).
+*/
 struct ConfigData
 {
 	std::string ip;
@@ -10,12 +15,16 @@ struct ConfigData
 	double prior_pitch, prior_yaw, prior_distance;
 	bool show_video_feed;
 
-	std::vector<std::string> model_names; //= {"Fast", "Medium", "Heavy"};
+	std::vector<std::string> model_names;
 	int selected_model;
 
 	static ConfigData getGenericConfig();
 };
 
+
+/**
+* Incharged of building/retrieving/saving a config object.
+*/
 class ConfigMgr
 {
 public:

--- a/Client/src/model/IPResolver.cpp
+++ b/Client/src/model/IPResolver.cpp
@@ -7,7 +7,7 @@
 
 std::string network::get_local_ip()
 {
-    const QHostAddress& localhost = QHostAddress(QHostAddress::LocalHost);
+    /*const QHostAddress& localhost = QHostAddress(QHostAddress::LocalHost);
     for (const QHostAddress& address : QNetworkInterface::allAddresses()) {
         
         if (address.protocol() == QAbstractSocket::IPv4Protocol && address != localhost)
@@ -17,5 +17,7 @@ std::string network::get_local_ip()
 #endif // _DEBUG
             return address.toString().toStdString();
         }   
-    }
+    }*/
+
+    return "127.0.0.1";
 }

--- a/Client/src/model/IPResolver.cpp
+++ b/Client/src/model/IPResolver.cpp
@@ -2,15 +2,20 @@
 
 #include <QTcpSocket>
 #include <QHostAddress>
+#include <QNetworkInterface>
 //#include <iostream>
 
 std::string network::get_local_ip()
 {
-    QTcpSocket socket;
-    std::string ip = "127.0.0.1";
-    socket.connectToHost("8.8.8.8", 53); // google DNS
-    if (socket.waitForConnected()) {
-        ip = socket.localAddress().toString().toStdString();
+    const QHostAddress& localhost = QHostAddress(QHostAddress::LocalHost);
+    for (const QHostAddress& address : QNetworkInterface::allAddresses()) {
+        
+        if (address.protocol() == QAbstractSocket::IPv4Protocol && address != localhost)
+        {
+#ifdef _DEBUG
+            qDebug() << address.toString();
+#endif // _DEBUG
+            return address.toString().toStdString();
+        }   
     }
-    return ip;
 }

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -6,10 +6,6 @@
 #include "../camera/CameraFactory.h"
 
 
-
-
-
-
 Presenter::Presenter(IView& view, TrackerFactory* t_factory, ConfigMgr* conf_mgr)
 {
 	this->conf_mgr = conf_mgr;
@@ -113,6 +109,10 @@ void Presenter::init_tracker(int type)
 				camera->height,
 				state.prior_distance,
 				tracker_factory->get_type(type));
+		}
+		else
+		{
+			this->t->update_distance_param(state.prior_distance);
 		}
 	}
 	else

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -177,7 +177,7 @@ void Presenter::run_loop()
 			view->paint_video_frame(mat);
 		}
 
-		cv::waitKey(35);
+		cv::waitKey(1000/state.video_fps);
 	}
 
 	camera->stop_camera();

--- a/Client/src/presenter/presenter.h
+++ b/Client/src/presenter/presenter.h
@@ -22,8 +22,10 @@ private:
 	ITrackerWrapper *t = NULL;
 	Camera *camera = NULL;
 
+	// Current program's state + config.
 	ConfigData state;
 	
+	// Filter which will be aplied to the tracking.
 	IFilter *filter;
 
 	IView* view;
@@ -41,12 +43,15 @@ private:
 	/**
 	* Stands for initializing or updating the internal UDP sender.
 	* If the passed IP and port are equal than the already existing, it
-	* does nothing.
+	* does nothing. This method updates the application state.
 	*/
 	void init_sender(std::string& ip, int port);
 
 	/**
-	* TODO
+	* Uses the tracker factory to build a new tracker. If the requested one is of the
+	* same type as the old one, the call will be ignored. 
+	* This method updates the application state.
+	* @param type Type ID of the desired model (Fast, medium, heavy)
 	*/
 	void init_tracker(int type);
 	

--- a/Client/src/presenter/presenter.h
+++ b/Client/src/presenter/presenter.h
@@ -58,7 +58,7 @@ private:
 	/**
 	* Uses the internal UDP sender to send the facedata to opentrack.
 	*/
-	void send_data(double* buffer_data, FaceData& facedata);
+	void send_data(double* buffer_data);
 
 	/**
 	* runs the recognition loop`.
@@ -68,6 +68,16 @@ private:
 	*	- updates (if needed) the UI with the painted image.
 	*/
 	void run_loop();
+
+	/**
+	* Updates presenter state with the current X,Y,Z,Yaw,Pitch,Roll recognized
+	*/
+	void update_tracking_data(FaceData& facedata);
+
+	/**
+	* Updates the stabilizer applied to the recognized facial landmarks.
+	*/
+	void update_stabilizer(const ConfigData &data);
 	
 public:
 	ConfigMgr* conf_mgr;

--- a/Client/src/tracker/ITrackerWrapper.h
+++ b/Client/src/tracker/ITrackerWrapper.h
@@ -5,6 +5,12 @@
 #include "opencv2/core/matx.hpp"
 
 
+/**
+* Possible model types. 
+* TRACKER_FAST = Less weights. Lighter, but could have less precission
+* TRACKER_MED = Half the way. Could offer a good tradeoff.
+* TRACKER_FULL = The heaviest. Could perform the best but also eats more CPU. 
+*/
 enum class TRACKER_TYPE
 {
 	TRACKER_FAST,
@@ -12,11 +18,19 @@ enum class TRACKER_TYPE
 	TRACKER_FULL
 };
 
+
 class ITrackerWrapper
 {
 public:
 	virtual ~ITrackerWrapper() {};
+	/**
+	* Detects a face, its landmarks and estimates a translation + rotation position.
+	* @param image
+	* @param face_data Where the results of the recognition will be stored
+	* @param filter Optional filter/operation which will be executed (if != nullptr) on the extracted facial landmarks.
+	*/
 	virtual void predict(cv::Mat& image, FaceData& face_data, IFilter* filter)=0;
+	virtual void update_distance_param(float new_distance) = 0;
 	virtual TRACKER_TYPE get_type()=0;
 };
 

--- a/Client/src/tracker/TrackerFactory.cpp
+++ b/Client/src/tracker/TrackerFactory.cpp
@@ -35,21 +35,22 @@ ITrackerWrapper* TrackerFactory::buildTracker(int im_width, int im_height, float
 	PositionSolver* solver = new PositionSolver(im_width, im_height, 0, 0, distance);
 
 	Tracker* t = nullptr;
-	//try
-	//{
+	try
+	{
 		t = new Tracker(
 			solver,
 			detect_wstr,
 			landmark_wstr
 		);
-	//}
-	/*catch (std::exception e)
+	}
+	catch (std::exception e)
 	{
 #ifdef _DEBUG
 		std::cout << "PROBLEM BUILDING TRACKER \n" << e.what() << std::endl;
 #endif
 		delete solver;
-	}*/
+		t = nullptr;
+	}
 
 	TrackerWrapper* wrapped = new TrackerWrapper(t, type);
 

--- a/Client/src/tracker/TrackerFactory.cpp
+++ b/Client/src/tracker/TrackerFactory.cpp
@@ -27,7 +27,6 @@ ITrackerWrapper* TrackerFactory::buildTracker(int im_width, int im_height, float
 		break;
 	}
 	
-
 	std::wstring detect_wstr = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(detect_path);
 	std::wstring landmark_wstr = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(landmark_path);
 

--- a/Client/src/tracker/TrackerFactory.h
+++ b/Client/src/tracker/TrackerFactory.h
@@ -4,6 +4,10 @@
 #include <string.h>
 #include <vector>
 
+
+/**
+* Builds TrackerWrapper objects which will be the ones used for making the detections.
+*/
 class TrackerFactory
 {
 private:
@@ -11,7 +15,12 @@ private:
 public:
 	TrackerFactory(std::string modeldir);
 	ITrackerWrapper* buildTracker(int im_width, int im_height, float distance, TRACKER_TYPE type= TRACKER_TYPE::TRACKER_FAST);
+
+	/**
+	* Set the list with the string identifiers of the available models.
+	*/
 	void get_model_names(std::vector<std::string>& names);
+
 	int get_type_id(TRACKER_TYPE type);
 	TRACKER_TYPE get_type(int type);
 };

--- a/Client/src/tracker/TrackerWrapper.cpp
+++ b/Client/src/tracker/TrackerWrapper.cpp
@@ -19,7 +19,7 @@ void TrackerWrapper::predict(cv::Mat& image, FaceData& face_data, IFilter* filte
 
 void TrackerWrapper::update_distance_param(float new_distance)
 {
-    this->model->solver->prior_distance = new_distance;
+    this->model->solver->set_prior_distance(new_distance);
 }
 
 TRACKER_TYPE TrackerWrapper::get_type()

--- a/Client/src/tracker/TrackerWrapper.cpp
+++ b/Client/src/tracker/TrackerWrapper.cpp
@@ -17,6 +17,11 @@ void TrackerWrapper::predict(cv::Mat& image, FaceData& face_data, IFilter* filte
     model->predict(image, face_data, filter);
 }
 
+void TrackerWrapper::update_distance_param(float new_distance)
+{
+    this->model->solver->prior_distance = new_distance;
+}
+
 TRACKER_TYPE TrackerWrapper::get_type()
 {
     return type;

--- a/Client/src/tracker/TrackerWrapper.h
+++ b/Client/src/tracker/TrackerWrapper.h
@@ -3,6 +3,8 @@
 #include "ITrackerWrapper.h"
 #include "model.h"
 
+
+// Just to decouple the model library from the application.
 class TrackerWrapper:ITrackerWrapper
 {
 private:
@@ -15,6 +17,7 @@ public:
 
 	// Inherited via ITrackerWrapper
 	virtual void predict(cv::Mat& image, FaceData& face_data, IFilter* filter) override;
+	void update_distance_param(float new_distance) override;
 	virtual TRACKER_TYPE get_type() override;
 };
 

--- a/Client/src/view/MainWindow.ui
+++ b/Client/src/view/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>420</width>
-    <height>578</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -68,6 +68,12 @@
     <bool>false</bool>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout_2">
+    <property name="spacing">
+     <number>5</number>
+    </property>
+    <property name="bottomMargin">
+     <number>1</number>
+    </property>
     <item>
      <spacer name="verticalSpacerTop">
       <property name="orientation">
@@ -85,7 +91,7 @@
      </spacer>
     </item>
     <item>
-     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
       <property name="spacing">
        <number>3</number>
       </property>
@@ -102,7 +108,7 @@
        <number>2</number>
       </property>
       <property name="bottomMargin">
-       <number>2</number>
+       <number>1</number>
       </property>
       <item>
        <widget class="QLabel" name="cameraView">
@@ -315,13 +321,13 @@
           </rect>
          </property>
          <property name="title">
-          <string>Initial parameters</string>
+          <string>Parameters</string>
          </property>
          <widget class="QLabel" name="label_8">
           <property name="geometry">
            <rect>
             <x>10</x>
-            <y>33</y>
+            <y>26</y>
             <width>61</width>
             <height>18</height>
            </rect>
@@ -334,7 +340,7 @@
           <property name="geometry">
            <rect>
             <x>90</x>
-            <y>34</y>
+            <y>27</y>
             <width>51</width>
             <height>20</height>
            </rect>
@@ -347,7 +353,7 @@
           <property name="geometry">
            <rect>
             <x>10</x>
-            <y>82</y>
+            <y>62</y>
             <width>121</width>
             <height>16</height>
            </rect>
@@ -360,10 +366,32 @@
           <property name="geometry">
            <rect>
             <x>19</x>
-            <y>105</y>
+            <y>85</y>
             <width>121</width>
             <height>22</height>
            </rect>
+          </property>
+         </widget>
+         <widget class="QCheckBox" name="landmarkStabChck">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>118</y>
+            <width>131</width>
+            <height>31</height>
+           </rect>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Experimental&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Apply a filter to reduce noise on the recognized facial landmarks. Can reduce noise and thus, make you able to reduce the amount of Acella fitlering in Opentrack, gaining responsiveness.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="toolTipDuration">
+           <number>-1</number>
+          </property>
+          <property name="text">
+           <string>Landmark stabilization</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </widget>
@@ -383,7 +411,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Save</string>
+          <string>Apply changes</string>
          </property>
         </widget>
         <widget class="QCheckBox" name="chkVideoPreview">
@@ -408,6 +436,19 @@
           <bool>true</bool>
          </property>
         </widget>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="trackerInfoLbl">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:7pt; color:#6b6b6b;&quot;&gt;X: Y: Z: Pitch: Yaw: Roll:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::RichText</enum>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
      </layout>

--- a/Client/src/view/WindowMain.cpp
+++ b/Client/src/view/WindowMain.cpp
@@ -112,8 +112,6 @@ ConfigData WindowMain::get_inputs()
 	ConfigData inputs = ConfigData();
 	inputs.ip = gp_box_address->findChild<QLineEdit*>("ipField")->text().toStdString();
 	inputs.port= gp_box_address->findChild<QLineEdit*>("portField")->text().toInt();
-	//inputs.prior_pitch = gp_box_priors->findChild<QLineEdit*>("pitchField")->text().toDouble();
-	//inputs.prior_yaw = gp_box_priors->findChild<QLineEdit*>("yawField")->text().toDouble();
 	inputs.prior_distance = gp_box_priors->findChild<QLineEdit*>("distanceField")->text().toDouble();
 	inputs.show_video_feed = check_video_preview->isChecked();
 	inputs.selected_model = cb_modelType->currentIndex();
@@ -127,8 +125,6 @@ void WindowMain::set_inputs(const ConfigData data)
 
 	gp_box_address->findChild<QLineEdit*>("ipField")->setText(data.ip.data());
 	gp_box_address->findChild<QLineEdit*>("portField")->setText(data.port==0 ? "" : QString::number(data.port));
-	//gp_box_priors->findChild<QLineEdit*>("pitchField")->setText(QString::number(data.prior_pitch));
-	//gp_box_priors->findChild<QLineEdit*>("yawField")->setText(QString::number(data.prior_yaw));
 	gp_box_priors->findChild<QLineEdit*>("distanceField")->setText(QString::number(data.prior_distance));
 	check_video_preview->setChecked(data.show_video_feed);
 

--- a/Client/src/view/WindowMain.h
+++ b/Client/src/view/WindowMain.h
@@ -47,6 +47,10 @@ private:
 	* Compacting the window to the content.
 	*/
 	void readjust_size();
+
+	/**
+	* Updates the view with the corresponding program state / config.
+	*/
 	void set_inputs(ConfigData data);
 
 

--- a/Client/src/view/WindowMain.h
+++ b/Client/src/view/WindowMain.h
@@ -28,6 +28,7 @@ public:
 	//Iview stuff
 	void connect_presenter(IPresenter* presenter);
 	void paint_video_frame(cv::Mat& img);
+	void show_tracking_data(ConfigData conf);
 	ConfigData get_inputs();
 	void update_view_state(ConfigData conf);
 	void set_tracking_mode(bool is_tracking);
@@ -38,9 +39,9 @@ public:
 private:
 	Ui::MainWindow ui;
 	QPushButton *btn_track, *btn_save;
-	QLabel* tracking_frame;
+	QLabel *tracking_frame, *tracking_info;
 	QGroupBox *gp_box_prefs, *gp_box_address, *gp_box_priors;
-	QCheckBox* check_video_preview;
+	QCheckBox *check_video_preview, *check_stabilization_landmarks;
 	QComboBox* cb_modelType;
 
 	/**

--- a/Client/src/view/i_view.h
+++ b/Client/src/view/i_view.h
@@ -22,6 +22,12 @@ public:
 	virtual void paint_video_frame(cv::Mat& img) = 0;
 
 	/**
+	* Show the tracking data on the UI
+	*/
+	virtual void show_tracking_data(ConfigData conf) = 0;
+
+
+	/**
 	* Sets the view in tracking or not tracking mode 
 	* (make changes on the GUI or update states)
 	*/


### PR DESCRIPTION
- Changed IPResolver.cpp to use `127.0.0.1` as the fallback instead of the local IP address. This potentially resolves #12  because the program no longer makes TCP requests to external servers.
- Changed OCVCamera.cpp to resize each captured frame instead of forcing the camera to certain resolutions it could not handle (#16 ). (Mentioned by @rbroker and reported in #11).
- When user changed distance parameter in the GUI, PositionResolver.cpp was not updating this parameter right. This fixes the bug of the view jumping all over the place.

- The program now saves resolution (thanks @rbroker) and fps in prefs.ini , which will be useful in the future.
- Added the option to disable the facial landmark stabilization filter.