### PR TITLE
Documentation update and Delay on open fixed

### DIFF
--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -6,11 +6,16 @@ OCVCamera::OCVCamera(int width, int height, int fps) :
 	size(width, height),
 	cap()
 {
+	CV_BACKEND = cv::CAP_DSHOW;
 	if (!is_camera_available())
 	{
-		throw std::runtime_error("No compatible camera found.");
+		// Check again with Media foundation backend
+		CV_BACKEND = cv::CAP_MSMF;
+		if (!is_camera_available())
+			throw std::runtime_error("No compatible camera found.");
 	}
 	is_valid = true;
+	cap.set(cv::CAP_PROP_BUFFERSIZE, 1);
 }
 
 OCVCamera::~OCVCamera()
@@ -22,7 +27,7 @@ bool OCVCamera::is_camera_available()
 {
 	bool available = false;
 
-	cap.open(0, cv::CAP_MSMF);
+	cap.open(0, CV_BACKEND);
 	available = cap.isOpened();
 	if (available)
 		cap.release();
@@ -32,7 +37,7 @@ bool OCVCamera::is_camera_available()
 
 void OCVCamera::start_camera()
 {
-	cap.open(0, cv::CAP_MSMF);
+	cap.open(0, CV_BACKEND);
 	if (!cap.isOpened())
 	{
 		throw std::runtime_error("No compatible camera found.");

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -22,7 +22,7 @@ bool OCVCamera::is_camera_available()
 {
 	bool available = false;
 
-	cap.open(0, 0);
+	cap.open(0, cv::CAP_MSMF);
 	available = cap.isOpened();
 	if (available)
 		cap.release();
@@ -32,7 +32,7 @@ bool OCVCamera::is_camera_available()
 
 void OCVCamera::start_camera()
 {
-	cap.open(0, 0);
+	cap.open(0, cv::CAP_MSMF);
 	if (!cap.isOpened())
 	{
 		throw std::runtime_error("No compatible camera found.");

--- a/Client/src/camera/OCVCamera.h
+++ b/Client/src/camera/OCVCamera.h
@@ -7,6 +7,7 @@ class OCVCamera : public Camera
 private:
 	cv::VideoCapture cap;
 	cv::Size size;
+	int CV_BACKEND;
 
 	bool is_camera_available();
 

--- a/Doc/USER_GUIDE.md
+++ b/Doc/USER_GUIDE.md
@@ -1,4 +1,4 @@
-# User guide
+# User guide: Setup, common problems and tips
 
 ## Configuring opentrack and AiTrack
 
@@ -14,7 +14,7 @@ Example of Opentrack configuration:
 ![](../Images/OpentrackConfig.png)
 ![](../Images/OpentrackConfig1.png)
 
-Then, on AITrack, just click "Start tracking". The program will use the default configuration, which assumes that opentrack is on the same machine and it's listening port is 4242 (Opentrack's default). In case you want to use other config, just change it on AITrack and save it. 
+Then, on AITrack, just click "Start tracking". The program will use the default configuration, which assumes that opentrack is on the same machine and it's listening port is 4242 (Opentrack's default). In case you want to use other config, just change it on AITrack and save it.  After that, just click "Start" in Opentrack.
 
 
 ## Common problems
@@ -24,18 +24,21 @@ Then, on AITrack, just click "Start tracking". The program will use the default 
 - If you find your view on the game making "strange jumps":
     - Look at the video preview on AITrack and confirm the facial landmarks are correctly positioned.
         - If not, check your illumination, and the angle your have your camera.
-    - If the landmarks are recognized correctly try fine-tunning the distance parameter on AITrack.
+    - If the landmarks are recognized correctly try fine-tunning the distance parameter on AITrack. (Don't forget to click **Apply** each time you make any change).
 
 - If the view makes "jumps" when you move your head try adjusting the curves on Opentrack (`Mapping` button).
     - See **Tips** section
     - Here is a video with some tips https://www.youtube.com/watch?v=u0TBI7SoGkc on how to configure your curves.
+
+- If you  move left/right my your goes up/down:
+    - You have to flip your X and Y axes in Opentrack (see screenshot above: Options>Output). 
 
 ## Tips
 
 Based on the testing made so far, here are some recommendations for getting the best performance:
  
 -  Configure well your movement curves on Opentrack. Leave a little "dead zone" at the beginning of each curve and use the asymetric mapping feature for "Pitch".
-- Position your camera at about 0.5-1 meters horizontally from your face.
+- Position your camera at about 0.5-2 meters horizontally from your face.
     * It's better if the camera is directly in front of you, but it doesn't mattter if you have some lateral offset.
 -  The camera should be, approximately,  at about your nose-level. Good positions are on top of our monitor, or at its base.
 - You shouldn't need to touch "Initial parameters" on AITrack. If you find the tracking is not accurate, fine-tune "Distance" parameter only to the actual value (distance from your face to the camera, in meters).

--- a/README.md
+++ b/README.md
@@ -28,11 +28,23 @@ AITrack uses its own tracking pipeline (based on neural networks) to estimate th
 5. Run `AITrack.exe` from AITrack and click "Start tracking". 
 6. Look around!
 
+### But... I don't have a webcam :(
+
+No problem. This program supports [Droid Cam](https://www.dev47apps.com/), so you're able to use your smartphone as a camera.
+
+### My webcam is too old
+
+Don't worry. AITrack supports low resolutions pretty well. Anything achieving at least 30fps and 480p will do the job fine.
+
+---
+
 **IMPORTANT:**
 In case you want to know more, please, head to the `Doc/` directory to find guides about usage. If you can't find there what you're looking for, feel free to post your question on the [issues page](https://github.com/AIRLegend/aitracker/issues).
 
+---
+
 ## Showoff videos
-[] TODO
+[<img src="https://img.youtube.com/vi/6uhcg43o7tc/hqdefault.jpg" width="50%">](https://youtu.be/6uhcg43o7tc)
 
 
 ## Bugs and Contributing


### PR DESCRIPTION
Changed implementation from OpenCVCamera  so that it uses DirectShow as a default backend which solves the problem of delay opening the video stream. For the systems in which it is not available (as it is more or less deprecated right now), it falls back to Microsfot Media Foundation backend, which is the recommended on Windows. This also makes possible to use Droid Cam as input source.