### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ healthchecksdb
 */Dependencies/*
 Client/models
 prefs.ini
+log.txt

--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -178,7 +178,6 @@
     <ClCompile Include="src\camera\OCVCamera.cpp" />
     <ClCompile Include="src\camera\CameraFactory.cpp" />
     <ClCompile Include="src\model\Config.cpp" />
-    <ClCompile Include="src\model\IPResolver.cpp" />
     <ClCompile Include="src\camera\Ps3Camera.cpp" />
     <ClCompile Include="src\presenter\presenter.cpp" />
     <ClCompile Include="src\Main.cpp" />
@@ -188,7 +187,7 @@
     <ClCompile Include="src\tracker\TrackerFactory.cpp" />
     <ClCompile Include="src\tracker\TrackerWrapper.cpp" />
     <QtRcc Include="res\Resource.qrc" />
-    <QtRcc Include="src\view\qml.qrc" />
+    <CustomBuild Include="src\view\Resource.qrc" />
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="src\view\WindowMain.h" />
@@ -202,7 +201,6 @@
     <ClInclude Include="Include\ps3eye.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="src\model\Config.h" />
-    <ClInclude Include="src\model\IPResolver.h" />
     <ClInclude Include="src\camera\Ps3Camera.h" />
     <ClInclude Include="src\presenter\i_presenter.h" />
     <ClInclude Include="src\presenter\presenter.h" />

--- a/Client/Client.vcxproj.filters
+++ b/Client/Client.vcxproj.filters
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="src\model\IPResolver.cpp" />
     <ClCompile Include="src\camera\Ps3Camera.cpp" />
     <ClCompile Include="src\presenter\presenter.cpp" />
     <ClCompile Include="src\Main.cpp" />
@@ -34,7 +33,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Include\ps3eye.h" />
-    <ClInclude Include="src\model\IPResolver.h" />
     <ClInclude Include="src\camera\Ps3Camera.h" />
     <ClInclude Include="src\presenter\i_presenter.h" />
     <ClInclude Include="src\presenter\presenter.h" />
@@ -78,7 +76,6 @@
     </QtMoc>
   </ItemGroup>
   <ItemGroup>
-    <QtRcc Include="src\view\qml.qrc" />
     <QtRcc Include="res\Resource.qrc">
       <Filter>Resource Files</Filter>
     </QtRcc>
@@ -119,5 +116,10 @@
     <QtUic Include="src\view\ConfigWindow.ui">
       <Filter>Form Files</Filter>
     </QtUic>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="src\view\Resource.qrc">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/Client/src/Main.cpp
+++ b/Client/src/Main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
     try
     {
         logger = spdlog::basic_logger_mt("aitrack", "log.txt", true);
+        logger->flush_on(spdlog::level::info);
     }
     catch (const spdlog::spdlog_ex& ex)
     {

--- a/Client/src/camera/CameraFactory.cpp
+++ b/Client/src/camera/CameraFactory.cpp
@@ -55,7 +55,8 @@ std::vector<std::shared_ptr<Camera>> CameraFactory::getCameras(CameraSettings& s
 	{
 		try
 		{
-			std::shared_ptr<Camera> c = std::make_shared<OCVCamera>(640, 480, 30, i);
+			std::shared_ptr<Camera> c = std::make_shared<OCVCamera>(settings.width, settings.height, settings.fps, i);
+			c->set_settings(settings);  // Brightness / Exposure
 			cams.push_back(std::move(c));
 			std::cout << "Found ID: " << i << std::endl;
 		}

--- a/Client/src/camera/CameraSettings.cpp
+++ b/Client/src/camera/CameraSettings.cpp
@@ -16,7 +16,7 @@ CameraSettings::CameraSettings(CameraSettings& settings)
 	gain = settings.gain;
 	fps = settings.fps;
 	width = settings.width;
-	height = settings.width;
+	height = settings.height;
 }
 
 CameraSettings::~CameraSettings()

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -34,6 +34,11 @@ bool OCVCamera::is_camera_available()
 	available = cap.isOpened();
 	if (available)
 	{
+		cv::Mat frame;
+		cap.read(frame);
+		if (frame.empty())
+			return false;
+
 		cam_native_width = cap.get(cv::CAP_PROP_FRAME_WIDTH);
 		cap.release();
 	}

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -32,9 +32,6 @@ OCVCamera::OCVCamera(int width, int height, int fps, int index) :
 	cap.set(cv::CAP_PROP_FRAME_HEIGHT, this->height);
 	cap.set(cv::CAP_PROP_FPS, this->fps);
 
-
-
-	//w_scale = (float)width / w;//(float)cam_native_width;
 	exposure, gain = -1;
 }
 

--- a/Client/src/camera/OCVCamera.h
+++ b/Client/src/camera/OCVCamera.h
@@ -9,7 +9,7 @@ private:
 	cv::Size size;
 	float w_scale;
 	float exposure, gain;
-	int cam_native_width;
+	int cam_native_height, cam_native_width, cam_native_fps;
 	int cam_index;
 	int CV_BACKEND;
 

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -16,9 +16,9 @@ ConfigData ConfigData::getGenericConfig()
 	conf.selected_model = 0;
 	conf.selected_camera = 0;
 	conf.num_cameras_detected = 0;
-	conf.video_width = 640;
-	conf.video_height = 480;
-	conf.video_fps = 30;
+	conf.video_width = -1;
+	conf.video_height = -1;
+	conf.video_fps = -1;
 	conf.use_landmark_stab = true;
 	conf.x, conf.y, conf.z, conf.pitch, conf.yaw, conf.roll = 0;
 	conf.cam_exposure = -1;

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -4,7 +4,6 @@
 #include "presenter.h"
 #include "opencv.hpp"
 
-#include "../model/IPResolver.h"
 #include "../camera/CameraFactory.h"
 
 
@@ -74,7 +73,7 @@ void Presenter::init_sender(std::string &ip, int port)
 	std::string ip_str = ip;
 	int port_dest = port;
 	if (QString(ip_str.data()).simplified().replace(" ", "").size() < 2)
-		ip_str = network::get_local_ip();
+		ip_str = "127.0.0.1";
 
 	if (port_dest == 0)
 		port_dest = 4242;

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -232,16 +232,12 @@ void Presenter::update_camera_params()
 	this->logger->info("Updating camera parameters...");
 	all_cameras[state.selected_camera]->set_settings(build_camera_params());
 
-	//if (state.video_height < 0 || state.video_width < 0)
-	//{
-		// The camera is using its default resolution so we must update our state
-		// to it. If we are using our custom resolution that wont be necessary.
+	// The camera can be using its default resolution so we must sync our state
+	// to it. If we are using our custom resolution that wont be necessary.
 	state.video_height = all_cameras[state.selected_camera]->height;
 	state.video_width = all_cameras[state.selected_camera]->width;
 	state.video_fps = all_cameras[state.selected_camera]->fps;
-	//}
-
-	this->logger->info("Updated camera parameters.");
+	this->logger->info("Updated camera parameters. {}x{}@{}", state.video_width, state.video_height, state.video_fps);
 }
 
 
@@ -292,6 +288,7 @@ void Presenter::save_prefs(const ConfigData& data)
 	state.video_fps = data.video_fps;
 	state.video_height = data.video_height;
 	state.video_width = data.video_width;
+
 	update_camera_params();
 
 

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -24,11 +24,9 @@ Presenter::Presenter(IView& view, std::unique_ptr<TrackerFactory>&& t_factory, s
 	// Init available model names to show in the GUI
 	this->tracker_factory->get_model_names(state.model_names);
 
-	// Setup a filter to stabilize the recognized facial landmarks if needed.
-	update_stabilizer(state);
-
 	CameraFactory camfactory;
 	CameraSettings camera_settings = build_camera_params();
+	logger->info("Searching for cameras...");
 	all_cameras = camfactory.getCameras(camera_settings);
 	logger->info("Number of recognized cameras: {}", all_cameras.size());
 
@@ -51,6 +49,12 @@ Presenter::Presenter(IView& view, std::unique_ptr<TrackerFactory>&& t_factory, s
 
 		// Build tracker
 		init_tracker(state.selected_model);
+
+		// Setup a filter to stabilize the recognized facial landmarks if needed.
+		update_stabilizer(state);
+
+		// Sync camera prefs between active camera and state.
+		update_camera_params();
 
 	}
 
@@ -227,6 +231,16 @@ void Presenter::update_camera_params()
 {
 	this->logger->info("Updating camera parameters...");
 	all_cameras[state.selected_camera]->set_settings(build_camera_params());
+
+	//if (state.video_height < 0 || state.video_width < 0)
+	//{
+		// The camera is using its default resolution so we must update our state
+		// to it. If we are using our custom resolution that wont be necessary.
+	state.video_height = all_cameras[state.selected_camera]->height;
+	state.video_width = all_cameras[state.selected_camera]->width;
+	state.video_fps = all_cameras[state.selected_camera]->fps;
+	//}
+
 	this->logger->info("Updated camera parameters.");
 }
 

--- a/Client/src/view/ConfigWindow.cpp
+++ b/Client/src/view/ConfigWindow.cpp
@@ -98,6 +98,7 @@ void ConfigWindow::update_view_state(ConfigData conf)
 	cb_modelType->clear();
 	for (std::string s : conf.model_names)
 		cb_modelType->addItem(QString(s.data()));
+	cb_modelType->setCurrentIndex(conf.selected_model);
 
 	check_stabilization_landmarks->setChecked(conf.use_landmark_stab);
 	distance_param->setText(QString::number(conf.prior_distance));

--- a/Client/src/view/ConfigWindow.ui
+++ b/Client/src/view/ConfigWindow.ui
@@ -13,6 +13,12 @@
     <height>368</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>419</width>
+    <height>368</height>
+   </size>
+  </property>
   <property name="maximumSize">
    <size>
     <width>419</width>
@@ -117,7 +123,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Input ID</string>
+        <string>Camera</string>
        </property>
       </widget>
      </item>

--- a/Client/src/view/ConfigWindow.ui
+++ b/Client/src/view/ConfigWindow.ui
@@ -70,13 +70,13 @@
      <item row="2" column="1">
       <widget class="QSpinBox" name="imgWidthSelector">
        <property name="minimum">
-        <number>640</number>
+        <number>-1</number>
        </property>
        <property name="maximum">
         <number>3000</number>
        </property>
        <property name="value">
-        <number>640</number>
+        <number>-1</number>
        </property>
       </widget>
      </item>
@@ -97,26 +97,26 @@
      <item row="3" column="1">
       <widget class="QSpinBox" name="imgHeightSelector">
        <property name="minimum">
-        <number>480</number>
+        <number>-1</number>
        </property>
        <property name="maximum">
         <number>3000</number>
        </property>
        <property name="value">
-        <number>480</number>
+        <number>-1</number>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
       <widget class="QSpinBox" name="fpsSelector">
        <property name="minimum">
-        <number>15</number>
+        <number>-1</number>
        </property>
        <property name="maximum">
         <number>120</number>
        </property>
        <property name="value">
-        <number>30</number>
+        <number>-1</number>
        </property>
       </widget>
      </item>

--- a/Client/src/view/MainWindow.ui
+++ b/Client/src/view/MainWindow.ui
@@ -184,6 +184,7 @@
         </property>
         <property name="font">
          <font>
+          <pointsize>10</pointsize>
           <weight>75</weight>
           <bold>true</bold>
          </font>
@@ -244,8 +245,13 @@
           <height>30</height>
          </size>
         </property>
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+         </font>
+        </property>
         <property name="text">
-         <string>🔧 Configuration⚙️</string>
+         <string>Configuration ⚙️</string>
         </property>
        </widget>
       </item>

--- a/Client/src/view/WindowMain.cpp
+++ b/Client/src/view/WindowMain.cpp
@@ -45,6 +45,7 @@ void WindowMain::paint_video_frame(cv::Mat& img)
 	if (check_video_preview->isChecked())
 		tracking_frame->setPixmap(
 			QPixmap::fromImage(QImage(img.data, img.cols, img.rows, img.step, QImage::Format_RGB888))
+				.scaled(400,280, Qt::KeepAspectRatio, Qt::FastTransformation)
 		);
 }
 
@@ -85,8 +86,6 @@ void WindowMain::set_tracking_mode(bool is_tracking)
 
 	conf_win->set_tracking_mode(is_tracking);
 }
-
-
 
 
 void WindowMain::update_view_state(ConfigData conf)

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Don't worry. AITrack supports low resolutions pretty well. Anything achieving at
 ---
 
 **IMPORTANT:**
-In case you want to know more, please, head to the `Doc/` directory to find guides about usage. If you can't find there what you're looking for, feel free to post your question on the [issues page](https://github.com/AIRLegend/aitracker/issues).
+In case you want to know more, please, head to the [project's wiki](https://github.com/AIRLegend/aitrack/wiki) to find guides about usage. If you can't find there what you're looking for, feel free to post your question on the [issues page](https://github.com/AIRLegend/aitracker/issues).
 
 **Thanks to Sims Smith**, who made a [video tutorial on how to setting up AITrack (v0.4)](https://youtu.be/LPlahUVPx4o) and **Stream Flight**, with a [tutorial for v0.5](https://www.youtube.com/watch?v=CMIwUg8NAlg). You can check them out.
 
-**ALSO IMPORTANT AND NOT COVERED IN THE VIDEO TUTORIAL**
+**ALSO IMPORTANT AND NOT COVERED IN THE VIDEO TUTORIALS**
 
 >Because of v0.4 is an older version, several punctualizations have to be made:
 >1) You don't need to configure "Use remote client" anymore if you're running Opentrack in your local machine.
@@ -58,9 +58,9 @@ In case you want to know more, please, head to the `Doc/` directory to find guid
 
 ## Bugs and Contributing
 
-If you encounter any bug/problem or you have some idea, post it on the [issues page](https://github.com/AIRLegend/aitracker/issues) to find help or further discussion. If you decide to fix something or implement a request, feel free to fork this repo, develop your new feature in a separate branch and then, make a PR to review it, here is the [guide to developers](Doc/DEVELOP.md). 
+If you encounter any bug/problem or you have some idea, post it on the [issues page](https://github.com/AIRLegend/aitracker/issues) to find help or further discussion. If you decide to fix something or implement a request, feel free to fork this repo, develop your new feature in a separate branch and then, make a PR to review it, here is the [guide to developers](Doc/DEVELOP.md) (also available in the wiki). 
 
-Also, there is a Discord server you can join to be aware of the news of the project, report problems or request features!
+Besides, there is a Discord server you can join to be aware of the news of the project, report problems or request features!
 
 <a href="https://discord.gg/HPZMdcx"><img src="https://image.flaticon.com/icons/svg/2111/2111370.svg" width="30px"/></a> Join the server!
 


### PR DESCRIPTION
This PR contains the changes to be included in the next quick update:

- Added logging system to ease the debugging of the rare (and hardly replicable) malfunctions.
- Disabled Brightness/Exposure control for OCVCamera because the value ranges differ from camera to camera.
- Preview now shows full captured video feed (not a cropped one).
- Fixed cropped video feed for some OCVCamera resolutions (those not having aspect ratio = 1.3333).