### PR TITLE
Dev

### DIFF
--- a/AITracker/src/PositionSolver.cpp
+++ b/AITracker/src/PositionSolver.cpp
@@ -90,8 +90,10 @@ void PositionSolver::solve_rotation(FaceData* face_data)
     for (int i = 0; i < 3; i++)
     {
         face_data->rotation[i] = rvec.at<double>(i, 0);
-        face_data->translation[i] = tvec.at<double>(i, 0);
+        face_data->translation[i] = tvec.at<double>(i, 0) * 10;
     }
+
+    correct_rotation(*face_data);
 
 }
 
@@ -133,5 +135,18 @@ void PositionSolver::get_euler(cv::Mat& rvec, cv::Mat& tvec)
         rvec
     );
 
+}
+
+void PositionSolver::correct_rotation(FaceData& face_data)
+{
+    float distance = -(face_data.translation[2]);
+    float lateral_offset = face_data.translation[1];
+    float verical_offset = face_data.translation[0];
+
+    float correction_yaw = std::atan(std::tan(lateral_offset / distance)) * TO_DEG;
+    float correction_pitch = std::atan(std::tan(verical_offset / distance)) * TO_DEG;
+
+    face_data.rotation[1] += correction_yaw;
+    face_data.rotation[0] += correction_pitch;
 }
 

--- a/AITracker/src/PositionSolver.h
+++ b/AITracker/src/PositionSolver.h
@@ -33,6 +33,7 @@ public:
 
 private:
 	static const int NB_CONTOUR_POINTS = 18;
+	const double TO_DEG = (180.0 / 3.14159265);
 
 	cv::Mat mat3dface;
 	cv::Mat mat3dcontour;
@@ -52,5 +53,11 @@ private:
 		Gets euler angles from rotation matrix.
 	*/
 	void get_euler(cv::Mat& rvec, cv::Mat& tvec);
+
+	/**
+	* Lateral/Vertical offset adds an error to the calculated rotation.
+	* This method corrects them.
+	*/
+	void correct_rotation(FaceData& face_data);
 };
 

--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -113,7 +113,7 @@
   </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Label="QtSettings">
     <QtInstall>$(QTDIR)</QtInstall>
-    <QtModules>core;uitools;widgets;quick</QtModules>
+    <QtModules>core;uitools;widgets;quick;</QtModules>
     <QtBuildConfig>debug</QtBuildConfig>
     <QtLibrarySearchPath>$(QTDIR)\lib;$(QtLibrarySearchPath)</QtLibrarySearchPath>
     <QtHeaderSearchPath>$(QTDIR)\include</QtHeaderSearchPath>
@@ -179,6 +179,7 @@
     <ClCompile Include="src\camera\CameraFactory.cpp" />
     <ClCompile Include="src\model\Config.cpp" />
     <ClCompile Include="src\camera\Ps3Camera.cpp" />
+    <ClCompile Include="src\model\UpdateChecker.cpp" />
     <ClCompile Include="src\presenter\presenter.cpp" />
     <ClCompile Include="src\Main.cpp" />
     <ClCompile Include="src\model\UDPSender.cpp" />
@@ -200,8 +201,10 @@
     <ClInclude Include="src\camera\CameraFactory.h" />
     <ClInclude Include="Include\ps3eye.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="src\version.h" />
     <ClInclude Include="src\model\Config.h" />
     <ClInclude Include="src\camera\Ps3Camera.h" />
+    <QtMoc Include="src\model\UpdateChecker.h" />
     <ClInclude Include="src\presenter\i_presenter.h" />
     <ClInclude Include="src\presenter\presenter.h" />
     <ClInclude Include="src\model\UDPSender.h" />

--- a/Client/Client.vcxproj.filters
+++ b/Client/Client.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="src\view\ConfigWindow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\model\UpdateChecker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Include\ps3eye.h" />
@@ -68,10 +71,16 @@
     <ClInclude Include="src\camera\CameraSettings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="src\view\WindowMain.h" />
     <QtMoc Include="src\view\ConfigWindow.h">
+      <Filter>Header Files</Filter>
+    </QtMoc>
+    <QtMoc Include="src\model\UpdateChecker.h">
       <Filter>Header Files</Filter>
     </QtMoc>
   </ItemGroup>

--- a/Client/src/Main.cpp
+++ b/Client/src/Main.cpp
@@ -1,5 +1,5 @@
 #ifndef _DEBUG
-#pragma comment(linker, "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
+//#pragma comment(linker, "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
 #endif // !_DEBUG
 
 
@@ -12,6 +12,10 @@
 
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
+
+
+#include "model/UpdateChecker.h"
+
 
 
 int main(int argc, char *argv[])

--- a/Client/src/Main.cpp
+++ b/Client/src/Main.cpp
@@ -1,5 +1,5 @@
 #ifndef _DEBUG
-//#pragma comment(linker, "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
+#pragma comment(linker, "/SUBSYSTEM:windows /ENTRY:mainCRTStartup")
 #endif // !_DEBUG
 
 

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -25,8 +25,7 @@ OCVCamera::OCVCamera(int width, int height, int fps, int index) :
 	}
 	
 	if (fps < 0)
-		this->fps = cam_native_fps;
-
+		this->fps = std::max(cam_native_fps, 30);
 
 	cap.set(cv::CAP_PROP_FRAME_WIDTH, this->width);
 	cap.set(cv::CAP_PROP_FRAME_HEIGHT, this->height);

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -25,7 +25,8 @@ OCVCamera::OCVCamera(int width, int height, int fps, int index) :
 	}
 	
 	if (fps < 0)
-		this->fps = std::max(cam_native_fps, 30);
+		this->fps = cam_native_fps;
+
 
 	cap.set(cv::CAP_PROP_FRAME_WIDTH, this->width);
 	cap.set(cv::CAP_PROP_FRAME_HEIGHT, this->height);
@@ -54,7 +55,7 @@ bool OCVCamera::is_camera_available()
 
 		cam_native_width = (int)cap.get(cv::CAP_PROP_FRAME_WIDTH);
 		cam_native_height = (int)cap.get(cv::CAP_PROP_FRAME_HEIGHT);
-		cam_native_fps = (int)cap.get(cv::CAP_PROP_FPS);
+		cam_native_fps = std::max(30, (int)cap.get(cv::CAP_PROP_FPS));
 		cap.release();
 	}
 	return available;
@@ -88,7 +89,7 @@ void OCVCamera::set_settings(CameraSettings& settings)
 {
 	this->width = settings.width > 0 ? settings.width : this->cam_native_width;
 	this->height = settings.height > 0 ? settings.height : this->cam_native_height;
-	this->fps = settings.fps > 0 ? settings.fps : this->cam_native_fps;
+	this->fps = settings.fps > 30 ? settings.fps : this->cam_native_fps;
 
 	// Disabled for the moment because of the different ranges in generic cameras.
 	//exposure = settings.exposure < 0 ? -1.0F : (float)settings.exposure/255;

--- a/Client/src/camera/OCVCamera.cpp
+++ b/Client/src/camera/OCVCamera.cpp
@@ -27,11 +27,6 @@ OCVCamera::OCVCamera(int width, int height, int fps, int index) :
 	if (fps < 0)
 		this->fps = cam_native_fps;
 
-
-	cap.set(cv::CAP_PROP_FRAME_WIDTH, this->width);
-	cap.set(cv::CAP_PROP_FRAME_HEIGHT, this->height);
-	cap.set(cv::CAP_PROP_FPS, this->fps);
-
 	exposure, gain = -1;
 }
 
@@ -68,6 +63,13 @@ void OCVCamera::start_camera()
 	{
 		throw std::runtime_error("No compatible camera found.");
 	}
+
+	// Force its properties each time we start the camera
+	// because if we force them with the device switched off
+	// bugs will occur (tiling, for example).
+	cap.set(cv::CAP_PROP_FRAME_WIDTH, this->width);
+	cap.set(cv::CAP_PROP_FRAME_HEIGHT, this->height);
+	cap.set(cv::CAP_PROP_FPS, this->fps);
 }
 
 void OCVCamera::stop_camera()
@@ -89,7 +91,7 @@ void OCVCamera::set_settings(CameraSettings& settings)
 {
 	this->width = settings.width > 0 ? settings.width : this->cam_native_width;
 	this->height = settings.height > 0 ? settings.height : this->cam_native_height;
-	this->fps = settings.fps > 30 ? settings.fps : this->cam_native_fps;
+	this->fps = settings.fps >= 30 ? settings.fps : this->cam_native_fps;
 
 	// Disabled for the moment because of the different ranges in generic cameras.
 	//exposure = settings.exposure < 0 ? -1.0F : (float)settings.exposure/255;

--- a/Client/src/model/Config.cpp
+++ b/Client/src/model/Config.cpp
@@ -20,6 +20,7 @@ ConfigData ConfigData::getGenericConfig()
 	conf.video_height = -1;
 	conf.video_fps = -1;
 	conf.use_landmark_stab = true;
+	conf.autocheck_updates = true;
 	conf.x, conf.y, conf.z, conf.pitch, conf.yaw, conf.roll = 0;
 	conf.cam_exposure = -1;
 	conf.cam_gain = -1;
@@ -55,6 +56,7 @@ void ConfigMgr::updateConfig(const ConfigData& data)
 	conf.setValue("cam_exposure", data.cam_exposure);
 	conf.setValue("cam_gain", data.cam_gain);
 	conf.setValue("selected_camera", data.selected_camera);
+	conf.setValue("autocheck_updates", data.autocheck_updates);
 }
 
 ConfigData ConfigMgr::getConfig()
@@ -74,6 +76,7 @@ ConfigData ConfigMgr::getConfig()
 	c.video_fps = conf.value("fps", 30).toInt();
 	c.cam_exposure= conf.value("cam_exposure", -1).toInt();
 	c.cam_gain = conf.value("cam_gain", -1).toInt();
+	c.autocheck_updates = conf.value("autocheck_updates", 1).toBool();
 	return c;
 }
 

--- a/Client/src/model/Config.h
+++ b/Client/src/model/Config.h
@@ -18,6 +18,7 @@ struct ConfigData
 	double prior_pitch, prior_yaw, prior_distance;
 	bool show_video_feed;
 	bool use_landmark_stab;
+	bool autocheck_updates;
 
 	float x, y, z, yaw, pitch, roll;
 

--- a/Client/src/model/UpdateChecker.cpp
+++ b/Client/src/model/UpdateChecker.cpp
@@ -1,0 +1,52 @@
+#include "UpdateChecker.h"
+
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <iostream>
+#include <QObject>
+
+
+UpdateChecker::UpdateChecker(std::string& version, IUpdateSub *obs):
+    request(),
+    manager(),
+    current_version(version)
+{
+    this->observer = obs;
+}
+
+void UpdateChecker::callback(QNetworkReply* reply)
+{
+    if (reply->error()) {
+        qDebug() << reply->errorString();
+        return;
+    }
+    QString answer = reply->readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(answer.toUtf8());
+    QJsonArray json_array = doc.array();
+    QJsonObject latest_update = json_array[0].toObject();
+
+    Version v(latest_update["tag_name"].toString().toStdString());
+
+    qDebug() << latest_update["tag_name"].toString();
+
+    this->observer->on_update_check_completed((current_version < v));
+}
+
+
+void UpdateChecker::get_latest_update(std::string& repo)
+{
+    QObject::connect(
+        &manager,
+        SIGNAL(finished(QNetworkReply*)), 
+        this, 
+        SLOT(callback(QNetworkReply*))
+    );
+
+    std::cout << "   REQUEST   "<<std::endl;
+
+    QString url = QString("https://api.github.com/repos/%1/releases").arg(QString::fromStdString(repo));
+    request.setUrl(QUrl(url));
+    manager.get(request);
+}

--- a/Client/src/model/UpdateChecker.h
+++ b/Client/src/model/UpdateChecker.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <string>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+
+
+class Version
+{
+public:
+	int stage; // alpha, beta or normal
+	std::string ver;
+
+	Version(std::string version): ver(), stage(10)
+	{
+		int index_dash = -1;
+
+		for (int i = 0; i < version.size(); i++) 
+		{
+			if (version.at(i) == *".")
+				continue;
+			if (version.at(i) == *"-")
+			{
+				index_dash = i;
+				break;
+			}
+			ver.push_back(version.at(i));
+		}
+		
+		if (index_dash > 0)
+		{
+			// Version id contains alpha/beta
+			if (version.at(index_dash + 1) == *"a")  // alpha
+				stage = 0;
+			if (version.at(index_dash + 1) == *"b")  // beta
+				stage = 1;
+			// Else, its a normal version
+		}
+	};
+
+    bool operator<(Version const& rhs) const
+    {		
+		int numbers_comparison = rhs.ver.compare(ver);
+		if (numbers_comparison == 0)
+		{
+			return stage < rhs.stage;
+		}
+		else 
+		{
+			return numbers_comparison > 0;
+		}
+    }
+};
+
+class IUpdateSub
+{
+public:
+	/*
+	* Callback to check whether a newer version is available.
+	*/
+	virtual void on_update_check_completed(bool update_exists) = 0;
+};
+
+
+
+class UpdateChecker : public QObject
+{
+Q_OBJECT
+
+private:
+	QNetworkRequest request;
+	QNetworkAccessManager manager;
+	IUpdateSub* observer;
+	Version current_version;
+
+public:
+	UpdateChecker(std::string &version, IUpdateSub *obs);
+	void get_latest_update(std::string &repo);
+	
+
+private slots:
+	void callback(QNetworkReply* reply);
+};
+
+
+

--- a/Client/src/presenter/presenter.cpp
+++ b/Client/src/presenter/presenter.cpp
@@ -192,9 +192,9 @@ void Presenter::run_loop()
 
 void Presenter::update_tracking_data(FaceData& facedata)
 {
-	this->state.x = facedata.translation[1] * 10;
-	this->state.y = facedata.translation[0] * 10;
-	this->state.z = facedata.translation[2] * 10;
+	this->state.x = facedata.translation[1];
+	this->state.y = facedata.translation[0];
+	this->state.z = facedata.translation[2];
 	this->state.yaw = facedata.rotation[1];   // Yaw
 	this->state.pitch = facedata.rotation[0];   //Pitch
 	this->state.roll = facedata.rotation[2];   //Roll

--- a/Client/src/presenter/presenter.h
+++ b/Client/src/presenter/presenter.h
@@ -4,6 +4,7 @@
 
 #include "../model/Config.h"
 #include "../model/UDPSender.h"
+#include "../model/UpdateChecker.h"
 #include "i_presenter.h"
 #include "../view/i_view.h"
 #include "../camera/Camera.h"
@@ -15,7 +16,7 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
-class Presenter : IPresenter
+class Presenter : IPresenter, IUpdateSub
 {
 private:
 	FaceData face_data;
@@ -96,6 +97,7 @@ private:
 
 public:
 	std::unique_ptr<ConfigMgr> conf_mgr;
+	std::unique_ptr<UpdateChecker> update_chkr;
 
 	Presenter(IView& view, std::unique_ptr<TrackerFactory>&& t_factory, std::unique_ptr<ConfigMgr>&& conf_mgr);
 
@@ -103,4 +105,7 @@ public:
 	void toggle_tracking();
 	void save_prefs(const ConfigData& data);
 	void close_program();
+
+	//IUpdatesub
+	void on_update_check_completed(bool update_exists);
 };

--- a/Client/src/version.h
+++ b/Client/src/version.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define AITRACK_VERSION "v0.6.2-alpha"

--- a/Client/src/view/ConfigWindow.cpp
+++ b/Client/src/view/ConfigWindow.cpp
@@ -26,7 +26,7 @@ ConfigWindow::ConfigWindow(IRootView *prev_window, QWidget *parent)
 	ip_field = gp_box_address->findChild<QLineEdit*>("ipField");
 	port_field = gp_box_address->findChild<QLineEdit*>("portField");
 
-
+	check_auto_update = findChild<QCheckBox*>("updateChckbox");
 	check_stabilization_landmarks = gp_box_priors->findChild<QCheckBox*>("landmarkStabChck");
 	cb_modelType = gp_box_priors->findChild<QComboBox*>("modeltypeSelect");
 	distance_param = gp_box_priors->findChild<QLineEdit*>("distanceField");
@@ -70,6 +70,7 @@ ConfigData ConfigWindow::get_inputs()
 	conf.port = port_field->text().toInt();
 	conf.use_landmark_stab = check_stabilization_landmarks->isChecked();
 	conf.selected_model = cb_modelType->currentIndex();
+	conf.autocheck_updates = check_auto_update->isChecked();
 
 	return conf;
 }
@@ -100,6 +101,7 @@ void ConfigWindow::update_view_state(ConfigData conf)
 		cb_modelType->addItem(QString(s.data()));
 	cb_modelType->setCurrentIndex(conf.selected_model);
 
+	check_auto_update->setChecked(conf.autocheck_updates);
 	check_stabilization_landmarks->setChecked(conf.use_landmark_stab);
 	distance_param->setText(QString::number(conf.prior_distance));
 

--- a/Client/src/view/ConfigWindow.h
+++ b/Client/src/view/ConfigWindow.h
@@ -36,7 +36,7 @@ private:
 	QPushButton *btn_apply;
 	QComboBox *input_camera, *cb_modelType;
 
-	QCheckBox* check_stabilization_landmarks;
+	QCheckBox *check_stabilization_landmarks, *check_auto_update;
 	QLineEdit* distance_param, * ip_field, * port_field;
 
 	QGroupBox *gp_box_camera_prefs, *gp_box_image_prefs, *gp_box_address, *gp_box_priors;;

--- a/Client/src/view/ConfigWindow.ui
+++ b/Client/src/view/ConfigWindow.ui
@@ -342,7 +342,7 @@
     </rect>
    </property>
    <property name="title">
-    <string>Parameters</string>
+    <string>Tracker parameters</string>
    </property>
    <widget class="QLabel" name="label_9">
     <property name="geometry">
@@ -415,6 +415,28 @@
      <bool>true</bool>
     </property>
    </widget>
+  </widget>
+  <widget class="QCheckBox" name="updateChckbox">
+   <property name="geometry">
+    <rect>
+     <x>241</x>
+     <y>290</y>
+     <width>131</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check for a newer version of the program on GitHub and notify me if available.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+   <property name="toolTipDuration">
+    <number>-1</number>
+   </property>
+   <property name="text">
+    <string>Autocheck updates</string>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
   </widget>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/Client/src/view/WindowMain.cpp
+++ b/Client/src/view/WindowMain.cpp
@@ -87,6 +87,7 @@ void WindowMain::set_tracking_mode(bool is_tracking)
 		tracking_frame->setText("No video input");
 	}
 
+	btn_config->setDisabled(is_tracking);
 	conf_win->set_tracking_mode(is_tracking);
 }
 

--- a/Client/src/view/WindowMain.cpp
+++ b/Client/src/view/WindowMain.cpp
@@ -1,6 +1,7 @@
 #include "WindowMain.h"
 
 #include "../presenter/presenter.h"
+#include "../version.h"
 #include <iostream>
 #include <QMessageBox>
 
@@ -10,6 +11,8 @@ WindowMain::WindowMain(QWidget *parent)
 {
 	ui.setupUi(this);
 	this->layout()->setSizeConstraint(QLayout::SetFixedSize);
+
+	this->setWindowTitle(QString("AITrack %1").arg(AITRACK_VERSION));
 
 	this->conf_win = new ConfigWindow(this);
 	this->conf_win->hide();

--- a/README.md
+++ b/README.md
@@ -41,20 +41,8 @@ Don't worry. AITrack supports low resolutions pretty well. Anything achieving at
 **IMPORTANT:**
 In case you want to know more, please, head to the [project's wiki](https://github.com/AIRLegend/aitrack/wiki) to find guides about usage. If you can't find there what you're looking for, feel free to post your question on the [issues page](https://github.com/AIRLegend/aitracker/issues).
 
-**Thanks to Sims Smith**, who made a [video tutorial on how to setting up AITrack (v0.4)](https://youtu.be/LPlahUVPx4o) and **Stream Flight**, with a [tutorial for v0.5](https://www.youtube.com/watch?v=CMIwUg8NAlg). You can check them out.
-
-**ALSO IMPORTANT AND NOT COVERED IN THE VIDEO TUTORIALS**
-
->Because of v0.4 is an older version, several punctualizations have to be made:
->1) You don't need to configure "Use remote client" anymore if you're running Opentrack in your local machine.
->2) You should take you time for [tweaking your curves in Opentrack](https://www.youtube.com/watch?v=u0TBI7SoGkc) to your preferences.
->3) Experiment with Opentrack's built in filters. Acella it's the recommended one at the moment. Configure it's smoothing parameter to reduce camera shaking.
-
----
-
 ## Showoff videos
-[<img src="https://img.youtube.com/vi/6uhcg43o7tc/hqdefault.jpg" width="50%">](https://youtu.be/6uhcg43o7tc)
-
+Check out this [wiki page](https://github.com/AIRLegend/aitrack/wiki/Videos) to see how it behaves.
 
 ## Bugs and Contributing
 

--- a/aitrack.json
+++ b/aitrack.json
@@ -1,0 +1,5 @@
+{
+    "version": "0.6.2-alpha",
+    "url": "https://github.com/AIRLegend/aitrack/releases/download/v0.6.2-alpha/aitrack-v0.6.2-alpha.zip",
+    "bin": "aitrack-v0.6.2-alpha/AITrack.exe"
+}


### PR DESCRIPTION
This PR contains the changes for the next release (0.6.2)

- Solves bug which set the camera FPS to 0, causing AITrack to crash.
- Added program number version on the window.
- Made an update notifier system.
- Added scoop app manifest so AITrack can be installed with this tool.
- Neutralize relative rotation on X/Y movements of the head.
- Fixed bug which made some cameras (most of them Logitech) to show duplicated video feeds along its horizontal axis when its resolution was changed.