### PR TITLE
some optimizations and jitter reduction

### DIFF
--- a/AITracker/src/PositionSolver.cpp
+++ b/AITracker/src/PositionSolver.cpp
@@ -261,10 +261,28 @@ void PositionSolver::correct_rotation(FaceData& face_data)
     float lateral_offset = (float)face_data.translation[1];
     float verical_offset = (float)face_data.translation[0];
 
+#ifdef OPTIMIZE_PositionSolver
+    float correction_yaw = (float)(std::atan(lateral_offset / distance) * TO_DEG); // (lateral_offset / distance) is already tangent, so only need atan to obtain radians
+    float correction_pitch = (float)(std::atan(verical_offset / distance) * TO_DEG); // (verical_offset / distance) is already tangent, so only need atan to obtain radians
+#else
     float correction_yaw = (float)(std::atan(std::tan(lateral_offset / distance)) * TO_DEG);
     float correction_pitch = (float)(std::atan(std::tan(verical_offset / distance)) * TO_DEG);
+#endif
 
     face_data.rotation[1] += correction_yaw;
     face_data.rotation[0] += correction_pitch;
+
+#ifdef OPTIMIZE_PositionSolver
+    // Limit yaw between -90.0 and +90.0 degrees after correction
+    if (face_data.rotation[1] >= 90.0)
+        face_data.rotation[1] = 90.0;
+    else if (face_data.rotation[1] <= -90.0)
+        face_data.rotation[1] = -90.0;
+    // Limit pitch between -90.0 and +90.0 degrees after correction
+    if (face_data.rotation[0] >= 90.0)
+        face_data.rotation[0] = 90.0;
+    else if (face_data.rotation[0] <= -90.0)
+        face_data.rotation[0] = -90.0;
+#endif
 }
 

--- a/AITracker/src/PositionSolver.cpp
+++ b/AITracker/src/PositionSolver.cpp
@@ -182,7 +182,7 @@ void PositionSolver::solve_rotation(FaceData* face_data)
     // We dont want the Z axis oversaturated.
     face_data->translation[2] /= 100;
 
-#ifdef DEBUG_OUTPUT_FACE_DATA
+#ifdef _DEBUG
     std::cout << face_data->to_string() << std::endl; // disable copy constructor and output to std::cout
 #endif
 

--- a/AITracker/src/data.cpp
+++ b/AITracker/src/data.cpp
@@ -15,13 +15,7 @@ FaceData::FaceData():
 #endif
 std::string FaceData::to_string()
 {
-#ifdef OPTIMIZE_Facedata
-	char buf[_MAX_PATH];
-	snprintf(buf, sizeof(buf), "Pitch %f  Yaw %f  Roll %f   X: %f, Y: %f, Z: %f",
-		this->rotation[0], this->rotation[1], this->rotation[2],
-		this->translation[0], this->translation[1], this->translation[2]);
-	std::string datastring = std::string(buf); // reduce multiple internal malloc/memcpy from std::string 
-#else
+#ifdef _DEBUG
 	std::string datastring =
 		std::string("Pitch ") + std::to_string(this->rotation[0]) +
 		std::string("  Yaw ") + std::to_string(this->rotation[1]) +
@@ -31,7 +25,10 @@ std::string FaceData::to_string()
 		std::string("   X: ") +
 		std::to_string(this->translation[0]) + ", Y: " +
 		std::to_string(this->translation[1]) + ", Z: " +
-		std::to_string(this->translation[2]) ;
+		std::to_string(this->translation[2]);
+#else
+	// disabled for performance
+	std::string datastring = std::string("to_string() disabled");
 #endif
 	return datastring;
 }

--- a/AITracker/src/data.cpp
+++ b/AITracker/src/data.cpp
@@ -9,9 +9,19 @@ FaceData::FaceData():
 	face_detected = false;
 }
 
-
+#define OPTIMIZE_Facedata 1
+#ifdef OPTIMIZE_Facedata
+#include <stdio.h>
+#endif
 std::string FaceData::to_string()
 {
+#ifdef OPTIMIZE_Facedata
+	char buf[_MAX_PATH];
+	snprintf(buf, sizeof(buf), "Pitch %f  Yaw %f  Roll %f   X: %f, Y: %f, Z: %f",
+		this->rotation[0], this->rotation[1], this->rotation[2],
+		this->translation[0], this->translation[1], this->translation[2]);
+	std::string datastring = std::string(buf); // reduce multiple internal malloc/memcpy from std::string 
+#else
 	std::string datastring =
 		std::string("Pitch ") + std::to_string(this->rotation[0]) +
 		std::string("  Yaw ") + std::to_string(this->rotation[1]) +
@@ -22,7 +32,7 @@ std::string FaceData::to_string()
 		std::to_string(this->translation[0]) + ", Y: " +
 		std::to_string(this->translation[1]) + ", Z: " +
 		std::to_string(this->translation[2]) ;
-
+#endif
 	return datastring;
 }
 

--- a/AITracker/src/filters.h
+++ b/AITracker/src/filters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#define OPTIMIZE_MAFilter 1
 
 class IFilter
 {
@@ -16,7 +17,9 @@ private:
 	int n_steps;
 
 	float *circular_buffer;
-	
+#ifdef OPTIMIZE_MAFilter
+	float *sum;
+#endif
 
 
 public:

--- a/AITracker/src/imageprocessor.cpp
+++ b/AITracker/src/imageprocessor.cpp
@@ -24,7 +24,6 @@ void ImageProcessor::normalize(cv::Mat& image)
 	cv::subtract(image, mean_scaling, image);
 }
 
-
 /*void ImageProcessor::cvt_format(float* from, float* dest, int dim_x, int dim_y)
 {
     for (int channel = 1; channel < 4; channel++)
@@ -80,4 +79,26 @@ void ImageProcessor::transpose(float* from, float* dest, int dim_x, int dim_y)
     }
 }
 
+#ifdef OPTIMIZE_ImageProcessor
+void ImageProcessor::normalize_and_transpose(cv::Mat& image, float* dest, int dim_x, int dim_y)
+{
+    const int stride = dim_x * dim_y;
 
+    // combine normalize and transpose methods to reduce for loops
+    float* from = (float*)image.data;
+    for (int channel = 0; channel < 3; channel++)
+    {
+        float std_scaline_for_channel = (float)std_scaling[channel];
+        float mean_scaling_for_channel = (float)mean_scaling[channel];
+
+        for (int i = 0; i < stride; i++)
+        {
+            float& from_reference = from[channel + i * 3]; // use a reference to reduce indexing
+            from_reference /= std_scaline_for_channel; /* remove internal for for loop of cv::divide(image, std_scaling, image); */
+            from_reference -= mean_scaling_for_channel; /* remove internal for for loop of cv::subtract(image, mean_scaling, image); */
+
+            dest[stride * channel + i] = from_reference; /* transpose */
+        }
+    }
+}
+#endif

--- a/AITracker/src/imageprocessor.h
+++ b/AITracker/src/imageprocessor.h
@@ -2,13 +2,18 @@
 
 #include "opencv.hpp"
 
+#define OPTIMIZE_ImageProcessor 1
+
 class ImageProcessor
 {
 public:
 	ImageProcessor();
 	void normalize(cv::Mat& image);
-	void cvt_format(float* from, float* dest, int dim_x = 224, int dim_y=224);
-	void transpose(float* from, float* dest, int dim_x = 224, int dim_y=224);
+	void cvt_format(float* from, float* dest, int dim_x = 224, int dim_y = 224);
+	void transpose(float* from, float* dest, int dim_x = 224, int dim_y = 224);
+#ifdef OPTIMIZE_ImageProcessor
+	void normalize_and_transpose(cv::Mat& image, float* dest, int dim_x = 224, int dim_y = 224);
+#endif
 
 private:
 	cv::Scalar mean_scaling, std_scaling;

--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -7,6 +7,7 @@
 #include <omp.h>
 
 
+#define OPTIMIZE_Tracker 1
 
 Tracker::Tracker(std::unique_ptr<PositionSolver>&& solver, std::wstring& detection_model_path, std::wstring& landmark_model_path):
     improc(),
@@ -52,8 +53,8 @@ void Tracker::predict(cv::Mat& image, FaceData& face_data, const std::unique_ptr
         int height = face_data.face_coords[2] - face_data.face_coords[0];
         int width = face_data.face_coords[3] - face_data.face_coords[1];
 
-        float scale_x = (float)width / 224;
-        float scale_y = (float)height / 224;
+        float scale_x = (float)width / 224.0f;
+        float scale_y = (float)height / 224.0f;
         detect_landmarks(cropped, face_data.face_coords[0], face_data.face_coords[1], scale_x, scale_y, face_data);
 
         if (filter != nullptr)
@@ -63,8 +64,19 @@ void Tracker::predict(cv::Mat& image, FaceData& face_data, const std::unique_ptr
     }
 }
 
+#define FIX_logit_boundary_conditions 1
+
 float logit(float p)
 {
+#ifdef FIX_logit_boundary_conditions
+    if (p >= 0.99999f) // prevent divide by zero, with consistent boundary 
+        p = 0.99999f; 
+    else if (p <= 0.0000001f) // prevent log(0), with consistent boundary
+        p = 0.0000001f; 
+
+    p = p / (1.0f - p);
+    return log(p) / 16.0f;
+#else
     if (p >= 1.0)
         p = 0.99999;
     else if (p <= 0.0)
@@ -72,14 +84,19 @@ float logit(float p)
 
     p = p / (1 - p);
     return log(p) / 16;
+#endif
 }
 
 void Tracker::detect_face(const cv::Mat& image, FaceData& face_data)
 {
     cv::Mat resized;
     cv::resize(image, resized, cv::Size(224, 224), NULL, NULL, cv::INTER_LINEAR);
+#ifdef OPTIMIZE_ImageProcessor
+    improc.normalize_and_transpose(resized, buffer_data); // combine methods
+#else
     improc.normalize(resized);
     improc.transpose((float*)resized.data, buffer_data);
+#endif
 
     Ort::Value input_tensor = Ort::Value::CreateTensor<float>(memory_info, buffer_data, tensor_input_size, tensor_input_dims, 4);
 
@@ -108,25 +125,25 @@ void Tracker::detect_face(const cv::Mat& image, FaceData& face_data)
     int y = p.y * 4;
 
 
-    face_data.face_detected = c > .7 ? true : false;
+    face_data.face_detected = c > 0.7f ? true : false;
 
     if (face_data.face_detected)
     {
         float face[] = { x - r, y - r, 2 * r, 2 * r };
-        float width = image.cols;
-        float height = image.rows;
+        float width = (float)image.cols;
+        float height = (float)image.rows;
 
-        face[0] *= width / 224;
-        face[2] *= width / 224;
-        face[1] *= height / 224;
-        face[3] *= height / 224;
+        face[0] *= width / 224.0f;
+        face[2] *= width / 224.0f;
+        face[1] *= height / 224.0f;
+        face[3] *= height / 224.0f;
 
         proc_face_detect(face, width, height);
 
-        face_data.face_coords[0] = face[0];
-        face_data.face_coords[1] = face[1];
-        face_data.face_coords[2] = face[2];
-        face_data.face_coords[3] = face[3];
+        face_data.face_coords[0] = (int)face[0];
+        face_data.face_coords[1] = (int)face[1];
+        face_data.face_coords[2] = (int)face[2];
+        face_data.face_coords[3] = (int)face[3];
     }
 
 }
@@ -137,8 +154,12 @@ void Tracker::detect_landmarks(const cv::Mat& image, int x0, int y0, float scale
 {
     cv::Mat resized;
     cv::resize(image, resized, cv::Size(224, 224), NULL, NULL, cv::INTER_LINEAR);
+#ifdef OPTIMIZE_ImageProcessor
+    improc.normalize_and_transpose(resized, buffer_data); // combine methods
+#else
     improc.normalize(resized);
     improc.transpose((float*)resized.data, buffer_data);
+#endif
 
     Ort::Value input_tensor = Ort::Value::CreateTensor<float>(memory_info, buffer_data, tensor_input_size, tensor_input_dims, 4);
 
@@ -164,10 +185,10 @@ void Tracker::proc_face_detect(float* face, float width, float height)
     int crop_x2 = (int)(x + w + w * 0.09f);
     int crop_y2 = (int)(y + h + h * 0.450f);
 
-    face[0] = std::max(0, crop_x1);
-    face[1] = std::max(0, crop_y1);
-    face[2] = std::min((int)width, crop_x2);
-    face[3] = std::min((int)height, crop_y2);
+    face[0] = (float)std::max(0, crop_x1);
+    face[1] = (float)std::max(0, crop_y1);
+    face[2] = (float)std::min((int)width, crop_x2);
+    face[3] = (float)std::min((int)height, crop_y2);
 }
 
 
@@ -179,6 +200,17 @@ void Tracker::proc_heatmaps(float* heatmaps, int x0, int y0, float scale_x, floa
         int offset = heatmap_size * landmark;
         int argmax = -100;
         float maxval = -100;
+#ifdef OPTIMIZE_Tracker
+        float* landmark_heatmap = &heatmaps[offset]; // reduce indexing
+        for (int i = 0; i < heatmap_size; i++)
+        {
+            if (landmark_heatmap[i] > maxval)
+            {
+                argmax = i;
+                maxval = landmark_heatmap[i];
+            }
+        }
+#else
         for (int i = 0; i < heatmap_size; i++)
         {
             if (heatmaps[offset + i] > maxval)
@@ -187,20 +219,20 @@ void Tracker::proc_heatmaps(float* heatmaps, int x0, int y0, float scale_x, floa
                 maxval = heatmaps[offset + i];
             }
         }
-
+#endif
         int x = argmax / 28;
         int y = argmax % 28;
 
 
-        float conf = heatmaps[offset + argmax];
+        // float conf = heatmaps[offset + argmax]; unreferenced local variable
         float res = 223;
 
-        int off_x = floor(res * (logit(heatmaps[66 * heatmap_size + offset + argmax])) + 0.1);
-        int off_y = floor(res * (logit(heatmaps[2 * 66 * heatmap_size + offset + argmax])) + 0.1);
+        int off_x = (int)floor(res * (logit(heatmaps[66 * heatmap_size + offset + argmax])) + 0.1f);
+        int off_y = (int)floor(res * (logit(heatmaps[2 * 66 * heatmap_size + offset + argmax])) + 0.1f);
 
 
-        float lm_x = (float)y0 + (float)(scale_x * (res * (float(x) / 27.) + off_x));
-        float lm_y = (float)x0 + (float)(scale_y * (res * (float(y) / 27.) + off_y));
+        float lm_x = (float)y0 + (float)(scale_x * (res * (float(x) / 27.0f) + off_x));
+        float lm_y = (float)x0 + (float)(scale_y * (res * (float(y) / 27.0f) + off_y));
 
         face_data.landmark_coords[2 * landmark] = lm_x;
         face_data.landmark_coords[2 * landmark + 1] = lm_y;

--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -69,9 +69,9 @@ void Tracker::predict(cv::Mat& image, FaceData& face_data, const std::unique_ptr
 float logit(float p)
 {
 #ifdef FIX_logit_boundary_conditions
-    if (p >= 0.99999f) // prevent divide by zero, with consistent boundary 
-        p = 0.99999f; 
-    else if (p <= 0.0000001f) // prevent log(0), with consistent boundary
+    if (p >= 0.9999999f) // prevent divide by zero, with consistent boundary and resolution
+        p = 0.9999999f; 
+    else if (p <= 0.0000001f) // prevent log(0), with consistent boundary and resolution
         p = 0.0000001f; 
 
     p = p / (1.0f - p);


### PR DESCRIPTION
OPTIMIZE_Facedata reduces malloc/memcpy from multiple std::string and std::to_string
OPTIMIZE_MAFilter uses this->sum as a cache to optimize calculation of the average in MAFilter::filter
added float suffix f to float constants to so that they are not double and calculations are not promoted to doubles to reduce conversions.
OPTIMIZE_ImageProcessor combines normalize and transpose methods to combine their for loops
FIX_logit_boundary_conditions modifies logit to consistently handle boundary conditions (e.g. > 0.99999f but less than 1.0f)
fix all automatic type conversion warnings with typecasts so that the conversions are visible since they consume CPU.  try to optimize typecast to use float computation but may use double computation in cases required  for the target value type or library function parameter.
OPTIMIZE_Tracker uses a reference to reduce array indexing
OPTIMIZE_PositionSolver reduces the number of double computations by using int64_t computations instead.
DEBUG_OUTPUT_FACE_DATA disables output to std::cout.
FIX_WARNING_PositionSolver fixes a build warning but the original computation trucates the fractional portion. Was it intentional?