### PR TITLE
Need a minimum amount of pixels for detection at farther distances

### DIFF
--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -30,8 +30,8 @@ Tracker::Tracker(std::unique_ptr<PositionSolver>&& solver, std::wstring& detecti
     session_lm = std::make_unique<Ort::Session>(*enviro, landmark_model_path.data(), session_options);
 
     // Face detector
-    float score_threshold = .8f;
-    float nms_threshold = .3f;
+    float score_threshold = .8;
+    float nms_threshold = .3;
     int topK = 50;
     face_detector = cv::FaceDetectorYN::create(
         std::string(detection_model_path.begin(), detection_model_path.end()),
@@ -82,44 +82,6 @@ float inline logit(float p)
     return log(p) / 16.0f;
 }
 
-float Tracker::get_distance_squared(float x0, float y0, float x1, float y1)
-{
-    // calculate distance squared.
-    // no need to for sqrt to obtain the smallest distance for optimization
-    float x_distance       = (x1 - x0);
-    float y_distance       = (y1 - y0);
-    float distance_squared = (x_distance * x_distance) + (y_distance * y_distance);
-    return distance_squared;
-}
-
-int Tracker::get_center_weighted_faces_row(const cv::Mat& image, const cv::Mat& faces)
-{
-    // get center coordinates for image
-    float image_center_x = (float)(image.rows / 2);
-    float image_center_y = (float)(image.cols / 2);
-
-    float smallest_distance_squared = 0.0f;
-    int   center_weighted_face_row  = -1;
-    for (int row = 0; row < faces.rows; row++)
-    {
-        // get center coordinates for faces at row
-        float x0     = faces.at<float>(row, 0);
-        float y0     = faces.at<float>(row, 1);
-        float face_w = faces.at<float>(row, 2);
-        float face_h = faces.at<float>(row, 3);
-        float face_center_x = x0 + (face_w / 2);
-        float face_center_y = y0 + (face_h / 2);
-
-        float distance_squared = get_distance_squared(image_center_x, image_center_y, face_center_x, face_center_y);
-        if ((center_weighted_face_row == -1) || (distance_squared < smallest_distance_squared))
-        {
-            center_weighted_face_row  = row;
-            smallest_distance_squared = distance_squared;
-        }
-    }
-    return center_weighted_face_row;
-}
-
 void Tracker::detect_face(const cv::Mat& image, FaceData& face_data)
 {
     cv::Mat resized, faces;
@@ -139,14 +101,10 @@ void Tracker::detect_face(const cv::Mat& image, FaceData& face_data)
     if (faces.rows > 0)
     {
         face_data.face_detected = true;
-        int  faces_row = 0;
-        bool center_weighted = true; // make center weighted face detection configurable
-        if (center_weighted)
-            faces_row = get_center_weighted_faces_row(image, faces);
-        float x0 = faces.at<float>(faces_row, 0);
-        float y0 = faces.at<float>(faces_row, 1);
-        float face_w = faces.at<float>(faces_row, 2);
-        float face_h = faces.at<float>(faces_row, 3);
+        float x0 = faces.at<float>(0, 0);
+        float y0 = faces.at<float>(0, 1);
+        float face_w = faces.at<float>(0, 2);
+        float face_h = faces.at<float>(0, 3);
 
         
         float w_ratio = (width / im_width);

--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -199,10 +199,13 @@ void Tracker::proc_face_detect(float* face, float width, float height)
     float w = face[2];
     float h = face[3];
 
-    int crop_x1 = (int)(x);
-    int crop_y1 = (int)(y);
-    int crop_x2 = (int)(x + w);  
-    int crop_y2 = (int)(y + h + h * 0.1f); // force a little taller BB so the chin tends to be covered
+    int additional_width_margin = (int)(w * 0.4f);
+    int additional_height_margin = (int)(h * 0.4f);
+
+    int crop_x1 = (int)(x - additional_width_margin);
+    int crop_y1 = (int)(y - additional_height_margin);
+    int crop_x2 = (int)(x + w + additional_width_margin);
+    int crop_y2 = (int)(y + h + additional_height_margin); // force a little taller BB so the chin tends to be covered
 
     face[0] = (float)std::max(0, crop_x1);
     face[1] = (float)std::max(0, crop_y1);

--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -139,12 +139,15 @@ void StandardTracker::detect_face(const cv::Mat& image, FaceData& face_data)
     if (faces.rows > 0)
     {
         face_data.face_detected = true;
-        float x0 = faces.at<float>(0, 0);
-        float y0 = faces.at<float>(0, 1);
-        float face_w = faces.at<float>(0, 2);
-        float face_h = faces.at<float>(0, 3);
-
-        
+        int  faces_row = 0;
+        bool center_weighted = true; // make center weighted face detection configurable
+        if (center_weighted)
+            faces_row = get_center_weighted_faces_row(image, faces);
+        float x0 = faces.at<float>(faces_row, 0);
+        float y0 = faces.at<float>(faces_row, 1);
+        float face_w = faces.at<float>(faces_row, 2);
+        float face_h = faces.at<float>(faces_row, 3);
+                
         float w_ratio = (width / im_width);
         float h_ratio = (height / im_height);
 

--- a/AITracker/src/model.cpp
+++ b/AITracker/src/model.cpp
@@ -157,8 +157,16 @@ void Tracker::proc_face_detect(float* face, float width, float height)
     float w = face[2];
     float h = face[3];
 
-    int additional_width_margin = (int)(w * 0.4f);
-    int additional_height_margin = (int)(h * 0.4f);
+    /* Need to increase the boundary for face detection by 10% to compensate for increased size due to yaw, pitch and roll */
+    /* But we also need a minimum amount of pixels for detection at farther distances where the face is smaller */
+    int additional_width_margin = (int)(w * 0.1f);
+    int minimum_width_margin    = (int)width / (4 * 10);
+    if (additional_width_margin < minimum_width_margin)
+        additional_width_margin = minimum_width_margin;
+    int additional_height_margin = (int)(h * 0.1f);
+    int minimum_height_margin    = (int)height / (4 * 10);
+    if (additional_height_margin < minimum_height_margin)
+        additional_height_margin = minimum_height_margin;
 
     int crop_x1 = (int)(x - additional_width_margin);
     int crop_y1 = (int)(y - additional_height_margin);

--- a/AITracker/src/model.h
+++ b/AITracker/src/model.h
@@ -48,7 +48,4 @@ private:
 	void proc_face_detect(float* face, float width = 1080, float height = 720);
 	void detect_landmarks(const cv::Mat& image, int x0, int y0, float scale_x, float scale_y, FaceData& face_data);
 	void proc_heatmaps(float* heatmaps, int x0, int y0, float scale_x, float scale_y, FaceData& face_data);
-
-	float get_distance_squared(float x0, float y0, float x1, float y1);
-	int get_center_weighted_faces_row(const cv::Mat& image, const cv::Mat& faces);
 };

--- a/Client/src/camera/CameraFactory.cpp
+++ b/Client/src/camera/CameraFactory.cpp
@@ -42,32 +42,41 @@ std::vector<std::shared_ptr<Camera>> CameraFactory::getCameras(CameraSettings& s
 {
 	std::vector<std::shared_ptr<Camera>> cams;
 
-	// Search first for any PS3 camera.
-	try
-	{
-		cams.push_back(std::make_shared<Ps3Camera>(640, 480, 60));
-		cams[0]->set_settings(settings);
-	}
-	catch (...)
-	{
-		std::cout << "No PS3 camera available." << std::endl;
-		cams.clear();
-	}
-
-
 	for (int i = 0; i < 5; i++)
 	{
+		bool bFoundPs3Camera = false;
+		// Search first for any PS3 camera.
 		try
 		{
-			std::shared_ptr<Camera> c = std::make_shared<OCVCamera>(settings.width, settings.height, settings.fps, i);
+			std::shared_ptr<Camera> c = std::make_shared<Ps3Camera>(640, 480, 60);
 			c->set_settings(settings);  // Brightness / Exposure
 			cams.push_back(std::move(c));
-			std::cout << "Found ID: " << i << std::endl;
+			bFoundPs3Camera = true;
+			std::cout << "Found PS3 camera ID: " << i << std::endl;
 		}
-		catch (const std::exception&)
+		catch (...)
 		{
-			std::cout << "Not found device" << i << std::endl;
 		}
+
+		if (!bFoundPs3Camera)
+		{
+			// Then search or OCV Camera.
+			try
+			{
+				std::shared_ptr<Camera> c = std::make_shared<OCVCamera>(settings.width, settings.height, settings.fps, i);
+				c->set_settings(settings);  // Brightness / Exposure
+				cams.push_back(std::move(c));
+				std::cout << "Found OCV camera ID: " << i << std::endl;
+			}
+			catch (const std::exception&)
+			{
+			}
+		}
+
+	}
+	if (cams.size() == 0)
+	{
+		std::cout << "No cameras found" << std::endl;
 	}
 
 	return cams;


### PR DESCRIPTION
Tracker::proc_face_detect increases the size of the face boundary by 10% to compensate for in increased face size due to yaw, pitch and roll.
But it also needs to guaranteed a minimum amount of pixels for faces at farther distances where the boundary is much smaller.

this fixes "Losing tracking at distances approx > 2 meters (v0.6.6 and v0.7.0)"
https://github.com/AIRLegend/aitrack/issues/173
Head tracking was tested at distances of 4 to 5 meters